### PR TITLE
Add nginx to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,27 @@
 
 # Fic-ai (ficai-web)
 
-Collaborative tagging
+Collaborative tagging.
+
+## Running locally
+
+Depends on [ficai-signals-server], follow the instructions there to run it in
+docker-compose.
+
+To run everything here inside docker:
+
+```bash
+docker-compose up -d --build nginx quasar-spa
+```
+
+If you'd prefer to run outside of docker, only start `nginx` and then follow
+the instructions below:
+
+```bash
+docker-compose up -d nginx
+```
+
+Open `http://localhost:9000` in your browser.
 
 ## Install the dependencies
 
@@ -70,3 +90,5 @@ quasar build
 ### Customize the configuration
 
 See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-vite/quasar-config-js).
+
+[ficai-signals-server]: https://github.com/ypoluektovich/ficai-signals-server/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,23 @@ services:
     restart: unless-stopped
     ports:
       - '8000:8000'
+  dockerhost:
+    container_name: dockerhost
+    image: qoomon/docker-host:3.0.5
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    mem_limit: 8M
+    restart: on-failure
+  nginx:
+    container_name: nginx
+    image: nginx:1.21.6-alpine
+    restart: unless-stopped
+    security_opt:
+      - "no-new-privileges:true"
+    ports:
+      - '9000:80'
+    depends_on:
+      - dockerhost
+    volumes:
+      - './local/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: nginx:1.21.6-alpine
     restart: unless-stopped
     security_opt:
-      - "no-new-privileges:true"
+      - 'no-new-privileges:true'
     ports:
       - '9000:80'
     depends_on:

--- a/local/nginx/default.conf
+++ b/local/nginx/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    access_log /var/log/nginx/fic.ai_access.log main;
+    error_log /var/log/nginx/fic.ai_error.log;
+
+    location /v1/ {
+        proxy_pass http://dockerhost:8080;
+    }
+    location / {
+        proxy_pass http://dockerhost:8000;
+    }
+}
+

--- a/local/nginx/default.conf
+++ b/local/nginx/default.conf
@@ -12,4 +12,3 @@ server {
         proxy_pass http://dockerhost:8000;
     }
 }
-

--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -14,19 +14,16 @@ declare module '@vue/runtime-core' {
 // "export default () => {}" function below (which runs individually
 // for each client)
 const signals_api = axios.create({
-  baseURL: 'http://localhost:8080/v1',
+  baseURL: '/v1',
   withCredentials: true,
 });
 
 // todo default error handler with popups
 
-const web_api = axios.create({ baseURL: 'http://127.0.0.1:8080/v1' });
-
 export default boot(({ app }) => {
   app.config.globalProperties.$axios = axios;
 
   app.config.globalProperties.$signals_api = signals_api;
-  app.config.globalProperties.$web_api = web_api;
 });
 
-export { signals_api, web_api };
+export { signals_api };


### PR DESCRIPTION
Adds an `nginx` container to mirror the setup in "production" that obviates the need from special CORS handling.

This seems to work fine when everything is running in docker-compose, but I wasn't actually able to run the SPA outside of docker by following the instructions in the README -- I have no `quasar` command. Is this meant to be installed by yarn or npm and need to be scoped with a `yarn run quasar` or something?
